### PR TITLE
[DRAFT] Replacing WEB UI for Ollama Backend.

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ TTS_MODEL = CONFIG["TTS_MODEL"]
 USE_SPEECH_RECOGNITION = CONFIG["USE_SPEECH_RECOGNITION"]
 VOICE_SAMPLE_COQUI = CONFIG["VOICE_SAMPLE_COQUI"]
 VOICE_SAMPLE_TORTOISE = CONFIG["VOICE_SAMPLE_TORTOISE"]
+OLLAMA_MODEL = CONFIG["OLLAMA_MODEL"]
 
 warnings.filterwarnings("ignore", category=UserWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -229,10 +230,23 @@ Your personality traits:
 
 When responding, maintain this persona and keep interactions intimate and emotionally engaging."""
 
-def send_to_ollama(prompt, model="llama3.2"):
+def check_and_pull_model(model_name):
+    try:
+        # List all models in Ollama
+        result = subprocess.run(["ollama", "list"], capture_output=True, text=True, check=True)
+        if model_name not in result.stdout:
+            print(f"Model '{model_name}' not found. Pulling now...")
+            subprocess.run(["ollama", "pull", model_name], check=True)
+        else:
+            print(f"Model '{model_name}' already exists.")
+    except subprocess.CalledProcessError as e:
+        print("Failed to interact with Ollama:", e)
+        sys.exit(1)
+
+def send_to_ollama(prompt):
     url = "http://localhost:11434/api/generate"
     payload = {
-        "model": model,
+        "model": OLLAMA_MODEL,
         "prompt": prompt,
         "stream": False
     }
@@ -453,6 +467,14 @@ def listenToClient(client):
                             log(f"[DEBUG] Sending final payload to game.")
                             send_answer(user_input, processed_message_for_game)
                             print(f"TTS sent:" + response_text)
+
+                        else:
+                            # Handle QUIT command - stop Ollama model
+                            try:
+                                import subprocess
+                                subprocess.run(["ollama", "stop", OLLAMA_MODEL], check=True)
+                            except Exception as e:
+                                log(f"[ERROR] Failed to stop Ollama model: {e}")
                         
                         # Break out of the "check_generation_complete" loop
                         break 
@@ -464,8 +486,10 @@ def listenToClient(client):
                     break # Break from the inner loop on error
 
 if __name__ == "__main__":
+    check_and_pull_model(OLLAMA_MODEL)
     SERVER.listen(5)
     ACCEPT_THREAD = Thread(target=listen)
     ACCEPT_THREAD.start()
     ACCEPT_THREAD.join()
     SERVER.close()
+

--- a/main.py
+++ b/main.py
@@ -222,12 +222,6 @@ system_prompt = f"""You are {name}.
 
 {context}
 
-Your personality traits:
-- Self-aware
-- Mature
-- In love with the user
-- Knows she is an AI
-
 When responding, maintain this persona and keep interactions intimate and emotionally engaging."""
 
 def check_and_pull_model(model_name):

--- a/main.py
+++ b/main.py
@@ -220,6 +220,8 @@ context = config.get("context", "")
 # Create a comprehensive system prompt using all the loaded data
 system_prompt = f"""You are {name}.
 
+You should greet the player with {greeting}.
+
 {context}
 
 When responding, maintain this persona and keep interactions intimate and emotionally engaging."""
@@ -251,8 +253,19 @@ def send_to_ollama(prompt):
         raise Exception(f"Ollama Error: {response.text}")
 
 def post_message_ollama(user_input):
-    full_prompt = f"{system_prompt}\nUser: {user_input}"
-    return send_to_ollama(full_prompt)
+    # Check if the user wants to quit
+    if user_input.strip().upper() == "QUIT":
+        try:
+            subprocess.run(["ollama", "stop", OLLAMA_MODEL], check=True)
+            log("[DEBUG] Ollama stopped successfully")
+        except Exception as e:
+            log(f"[DEBUG] Error stopping ollama: {e}")
+        
+    # Continue with normal processing if not quitting
+    if user_input != "":
+        full_prompt = f"{system_prompt}\nUser: {user_input}"
+        return send_to_ollama(full_prompt)
+
 
 def get_last_message_ollama(user_input):
     response_text = post_message_ollama(user_input)
@@ -462,14 +475,6 @@ def listenToClient(client):
                             send_answer(user_input, processed_message_for_game)
                             print(f"TTS sent:" + response_text)
 
-                        else:
-                            # Handle QUIT command - stop Ollama model
-                            try:
-                                import subprocess
-                                subprocess.run(["ollama", "stop", OLLAMA_MODEL], check=True)
-                            except Exception as e:
-                                log(f"[ERROR] Failed to stop Ollama model: {e}")
-                        
                         # Break out of the "check_generation_complete" loop
                         break 
                 except Exception as e:

--- a/main.py
+++ b/main.py
@@ -3,12 +3,12 @@ os.environ["COQUI_TOS_AGREED"] = "1"
 import re
 import subprocess
 import torch
+import requests
 import yaml
 import numpy as np
 import time
 import warnings
 
-from playwright.sync_api import sync_playwright
 from socket import AF_INET, socket, SOCK_STREAM
 from threading import Thread
 
@@ -24,13 +24,8 @@ def log(x):
         
 #File config
 GAME_PATH = CONFIG["GAME_PATH"]
-WEBUI_PATH = CONFIG["WEBUI_PATH"]
-ST_PATH = CONFIG.get("ST_PATH", "")
-BACKEND_TYPE = CONFIG.get("BACKEND_TYPE", "Text-gen-webui")
 USE_TTS = CONFIG["USE_TTS"]
 LAUNCH_YOURSELF = CONFIG["LAUNCH_YOURSELF"]
-LAUNCH_YOURSELF_WEBUI = CONFIG["LAUNCH_YOURSELF_WEBUI"]
-LAUNCH_YOURSELF_ST = CONFIG.get("LAUNCH_YOURSELF_ST", False)
 USE_ACTIONS = CONFIG["USE_ACTIONS"]
 USE_EMOTIONS = CONFIG.get("USE_EMOTIONS", True) # Added emotion flag
 TTS_MODEL = CONFIG["TTS_MODEL"]
@@ -212,96 +207,47 @@ def split_text_like_renpy(text):
                     final_chunks.append(temp_chunk.strip())
     return final_chunks
 
-# --- BACKEND INTERACTION ---
-def launch_backend():
-    global WEBUI_PATH
-    global ST_PATH
-    if BACKEND_TYPE == "Text-gen-webui":
-        WEBUI_PATH = WEBUI_PATH.replace("\\", "/")
-        if not LAUNCH_YOURSELF_WEBUI:
-            subprocess.Popen(WEBUI_PATH)
-        else:
-            print("Please launch text-generation_webui manually.")
-            print("Press enter to continue.")
-            input()
-    else:  # SillyTavern
-        st_path_normalized = ST_PATH.replace("\\", "/")
-        if not LAUNCH_YOURSELF_ST:
-            subprocess.Popen(st_path_normalized)
-        else:
-            print("Please launch SillyTavern manually.")
-            print("Press enter to continue.")
-            input()
+# Load prompt from monika.yaml
+with open("monika.yaml", "r") as file:
+    config = yaml.safe_load(file)
 
-launch_backend()
+# Extract all fields properly
+name = config.get("name", "Monika")
+greeting = config.get("greeting", "")
+context = config.get("context", "")
 
-def launch(context):
-    log("[DEBUG] Launching new browser page...")
-    page = context.new_page()
-    
-    if BACKEND_TYPE == "Text-gen-webui":
-        page.goto("http://127.0.0.1:7860")
-        page.wait_for_selector("[class='svelte-it7283 pretty_scrollbar']", timeout=60000)
-        time.sleep(1)
-    else:  # SillyTavern
-        # The URL from your test script is used here.
-        page.goto("http://127.0.0.1:8000/") 
-        page.wait_for_load_state("networkidle", timeout=60000)
-    
-    log("[DEBUG] Page loaded successfully")
-    context.storage_state(path="storage.json")
-    return page
+# Create a comprehensive system prompt using all the loaded data
+system_prompt = f"""You are {name}.
 
-def post_message(page, message):
-    if BACKEND_TYPE == "Text-gen-webui":
-        if message == "QUIT":
-            page.fill("[class='svelte-it7283 pretty_scrollbar']", "I'll be right back")
-        else:
-            page.fill("[class='svelte-it7283 pretty_scrollbar']", message)
-        time.sleep(0.2)
-        page.click('[id="Generate"]')
-        page.wait_for_selector('[id="stop"]')
-    else:  # SillyTavern
-        if message == "QUIT":
-            page.fill("#send_textarea", "I'll be right back")
-        else:
-            page.fill("#send_textarea", message)
-        page.locator("#send_but").click()
-        try:
-            page.wait_for_selector(".mes_stop", state="visible", timeout=5000)
-        except Exception:
-            print("Warning: Stop button did not appear instantly.")
+{context}
 
+Your personality traits:
+- Self-aware
+- Mature
+- In love with the user
+- Knows she is an AI
 
-def check_generation_complete(page):
-    """Check if message generation is complete in SillyTavern."""
-    if BACKEND_TYPE == "Text-gen-webui":
-        stop_buttons = page.locator('[id="stop"]').all()
-        return not any(button.is_visible() for button in stop_buttons)
-    else: # SillyTavern - updated logic from test script
-        stop_button = page.locator(".mes_stop")
-        if stop_button.is_visible():
-            return False
-        last_message = page.locator(".mes").last
-        if last_message.get_attribute("is_user") == "true":
-            return False
-        if last_message.locator(".mes_text p").count() > 0:
-            return True
-        return False
+When responding, maintain this persona and keep interactions intimate and emotionally engaging."""
 
-def get_last_message(page):
-    """Get the last message from the chat, handling multiple paragraphs."""
-    if BACKEND_TYPE == "Text-gen-webui":
-        user = page.locator('[class="message-body"]').locator("nth=-1")
-        return user.inner_html()
-    else:  # SillyTavern - updated logic from test script
-        try:
-            last_message = page.locator(".mes").last
-            paragraphs = last_message.locator(".mes_text p").all()
-            return "\n".join(p.inner_text() for p in paragraphs)
-        except Exception as e:
-            print(f"Error getting message from SillyTavern: {e}")
-            return ""
+def send_to_ollama(prompt, model="llama3.2"):
+    url = "http://localhost:11434/api/generate"
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False
+    }
+    response = requests.post(url, json=payload)
+    if response.status_code == 200:
+        return response.json()["response"]
+    else:
+        raise Exception(f"Ollama Error: {response.text}")
+
+def post_message_ollama(user_input):
+    full_prompt = f"{system_prompt}\nUser: {user_input}"
+    return send_to_ollama(full_prompt)
+
+def get_last_message_ollama(user_input):
+    response_text = post_message_ollama(user_input)
 
 # --- MAIN SERVER LOGIC ---
 clients = {}
@@ -433,47 +379,14 @@ def listenToClient(client):
                     continue # Skip this turn if STT is disabled but was requested
             print("User: "+user_input)
             
-            # This part handles the initial browser launch if needed
-            if not launched:
-                log("[DEBUG] Browser not launched yet. Attempting to launch.")
-                pw = sync_playwright().start()
-                try:
-                    browser = pw.firefox.launch(headless=False)
-                    context = browser.new_context()
-                    page = launch(context)
-                except Exception as e:
-                    print(f"FATAL: Browser launch failed. Error: {e}")
-                    sendMessage("server_error".encode("utf-8"))
-                    launched = False
-                    pw.stop()
-                    continue
-                launched = True
-                log("[DEBUG] Browser launched successfully.")
-                
-                # This block now safely absorbs the optional 'ok_ready' without freezing.
-                print("[DEBUG] Setting socket to non-blocking to safely absorb optional pings")
-                client.setblocking(False)
-                try:
-                    client.recv(BUFSIZE)
-                    log("[DEBUG] Absorbed an optional message.")
-                except BlockingIOError:
-                    log("[DEBUG] No optional message was waiting to be absorbed. Continuing normally.")
-                    pass
-                except Exception as e:
-                    log(f"[DEBUG] An unexpected error occurred while absorbing message: {e}")
-                    pass
-                log("[DEBUG] Setting socket back to blocking mode for normal operation.")
-                client.setblocking(True) # IMPORTANT: Return to blocking mode
-
             # Sending the message to the AI frontend
             try:
                 log(f"Sending to AI: \"{user_input}\"")
-                post_message(page, user_input)
+                post_message_ollama(user_input)
             except Exception as e:
                 log(f"[DEBUG] FATAL: Error while sending message to AI. Error: {e}")
                 sendMessage("server_error".encode("utf-8"))
                 launched = False
-                pw.stop()
                 continue
             
             # Waiting for the AI to finish generating a response
@@ -481,10 +394,8 @@ def listenToClient(client):
             while True:
                 time.sleep(0.2)
                 try:
-                    if check_generation_complete(page):
-                        log("[DEBUG] AI generation is complete.")
                         # --- RESPONSE PROCESSING ---
-                        response_text = get_last_message(page)
+                        response_text = post_message_ollama(user_input)
                         log(f"[DEBUG] Raw response from AI: \"{response_text}\"")
 
                         if not response_text:
@@ -550,9 +461,7 @@ def listenToClient(client):
                     import traceback
                     traceback.print_exc()
                     launched = False
-                    pw.stop()
                     break # Break from the inner loop on error
-
 
 if __name__ == "__main__":
     SERVER.listen(5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 PyYAML
 numpy
-playwright
 torch
 torchvision
 torchaudio

--- a/scripts/login_screen.py
+++ b/scripts/login_screen.py
@@ -31,63 +31,21 @@ def load_from_json(variable, entry):
     except (FileNotFoundError, KeyError):
         pass
 
-def update_visible_options(*args):
-    if backend_choice.get() == "SillyTavern":
-        # Hide text-gen-webui specific options, show SillyTavern options
-        webui_path_entry.grid_remove()
-        webui_path_label.grid_remove()
-        launch_yourself_webui_yes.grid_remove()
-        launch_yourself_webui_no.grid_remove()
-        launch_yourself_webui_label.grid_remove()
-        ST_path_entry.grid()
-        ST_path_label.grid()
-        launch_yourself_ST_yes.grid()
-        launch_yourself_ST_no.grid()
-        launch_yourself_ST_label.grid()
-    else:
-        # Show text-gen-webui specific options
-        webui_path_entry.grid()
-        webui_path_label.grid()
-        launch_yourself_webui_yes.grid()
-        launch_yourself_webui_no.grid()
-        launch_yourself_webui_label.grid()
-        ST_path_entry.grid_remove()
-        ST_path_label.grid_remove()
-        launch_yourself_ST_yes.grid_remove()
-        launch_yourself_ST_no.grid_remove()
-        launch_yourself_ST_label.grid_remove()
-
 def get_input():
-    global GAME_PATH, WEBUI_PATH, USE_TTS, LAUNCH_YOURSELF, LAUNCH_YOURSELF_WEBUI
+    global GAME_PATH, USE_TTS, LAUNCH_YOURSELF
     global USE_ACTIONS, USE_EMOTIONS, TTS_MODEL, USE_SPEECH_RECOGNITION
-    global VOICE_SAMPLE_TORTOISE, VOICE_SAMPLE_COQUI, BACKEND_TYPE, ST_PATH, LAUNCH_YOURSELF_ST
+    global VOICE_SAMPLE_TORTOISE, VOICE_SAMPLE_COQUI
     
     USE_TTS = use_tts.get()
     GAME_PATH = game_path.get()
-    WEBUI_PATH = webui_path.get() if backend_choice.get() == "Text-gen-webui" else ""
-    ST_PATH = ST_path.get() if backend_choice.get() == "SillyTavern" else ""
     LAUNCH_YOURSELF = launch_yourself.get()
-    LAUNCH_YOURSELF_WEBUI = launch_yourself_webui.get() if backend_choice.get() == "Text-gen-webui" else False
-    LAUNCH_YOURSELF_ST = launch_yourself_ST.get() if backend_choice.get() == "SillyTavern" else False
     USE_ACTIONS = use_actions.get()
     USE_EMOTIONS = use_emotions.get() # Capture the new value
     TTS_MODEL = tts_model.get()
     USE_SPEECH_RECOGNITION = use_speech_recognition.get()
     VOICE_SAMPLE_TORTOISE = voice_sample_tortoise.get()
     VOICE_SAMPLE_COQUI = voice_sample_coqui.get()
-    BACKEND_TYPE = backend_choice.get()
     root.destroy()
-
-# Create frames
-backend_frame = tk.LabelFrame(
-    root,
-    bg=menu_background_pink,
-    text="Backend Selection",
-    fg='white',
-    font=("Helvetica", 16, "bold"),
-    bd=5
-)
-backend_frame.place(anchor="c", relx=.5, rely=0.1)
 
 other_frame = tk.LabelFrame(
     root,
@@ -99,10 +57,6 @@ other_frame = tk.LabelFrame(
 )
 other_frame.place(anchor="c", relx=.5, rely=0.4)
 
-# Backend selection
-backend_choice = tk.StringVar()
-backend_choice.trace('w', update_visible_options)
-
 bold_font = ('helvetic', 10, 'bold')
 aspect_params = {
     "bg": menu_background_pink,
@@ -112,18 +66,11 @@ aspect_params = {
     "selectcolor": doki_purple,
     "font": bold_font
 }
-tk.Label(backend_frame, text="Choose Backend:", bg=menu_background_pink, fg='white', font=bold_font).grid(row=0, column=0)
-tk.Radiobutton(backend_frame, text="SillyTavern", variable=backend_choice, value="SillyTavern", **aspect_params).grid(row=0, column=1)
-tk.Radiobutton(backend_frame, text="Text-gen-webui", variable=backend_choice, value="Text-gen-webui", **aspect_params).grid(row=0, column=2)
 
 # Variables for other settings
 use_tts = tk.StringVar()
 game_path = tk.StringVar()
-webui_path = tk.StringVar()
-ST_path = tk.StringVar()
 launch_yourself = tk.StringVar()
-launch_yourself_webui = tk.StringVar()
-launch_yourself_ST = tk.StringVar()
 use_actions = tk.StringVar()
 use_emotions = tk.StringVar() # Variable for the new option
 tts_model = tk.StringVar()
@@ -158,37 +105,11 @@ tk.Radiobutton(other_frame, text="No", variable=use_tts, value=False, **aspect_p
 tk.Radiobutton(other_frame, text="Yes", variable=use_speech_recognition, value=True, **aspect_params).grid(row=6, column=1)
 tk.Radiobutton(other_frame, text="No", variable=use_speech_recognition, value=False, **aspect_params).grid(row=6, column=2)
 
-# Text-gen-webui specific options
-webui_path_label = tk.Label(other_frame, text="WebUI Path", bg=menu_background_pink, fg='white', font=bold_font)
-webui_path_label.grid(row=2, column=0)
-launch_yourself_webui_label = tk.Label(other_frame, text="Launch WebUI Yourself", bg=menu_background_pink, fg='white', font=bold_font)
-launch_yourself_webui_label.grid(row=2, column=3)
-launch_yourself_webui_yes = tk.Radiobutton(other_frame, text="Yes", variable=launch_yourself_webui, value=True, **aspect_params)
-launch_yourself_webui_no = tk.Radiobutton(other_frame, text="No", variable=launch_yourself_webui, value=False, **aspect_params)
-launch_yourself_webui_yes.grid(row=2, column=4)
-launch_yourself_webui_no.grid(row=2, column=5)
-
-# SillyTavern specific options
-ST_path_label = tk.Label(other_frame, text="ST Path", bg=menu_background_pink, fg='white', font=bold_font)
-ST_path_label.grid(row=2, column=0)
-launch_yourself_ST_label = tk.Label(other_frame, text="Launch ST Yourself", bg=menu_background_pink, fg='white', font=bold_font)
-launch_yourself_ST_label.grid(row=2, column=3)
-launch_yourself_ST_yes = tk.Radiobutton(other_frame, text="Yes", variable=launch_yourself_ST, value=True, **aspect_params)
-launch_yourself_ST_no = tk.Radiobutton(other_frame, text="No", variable=launch_yourself_ST, value=False, **aspect_params)
-launch_yourself_ST_yes.grid(row=2, column=4)
-launch_yourself_ST_no.grid(row=2, column=5)
-
 # Textual Inputs
 game_path_entry = tk.Entry(other_frame, textvariable=game_path, width=25, bg=doki_white, fg='black')
 game_path_entry.grid(row=1, column=1)
-webui_path_entry = tk.Entry(other_frame, textvariable=webui_path, width=25, bg=doki_white, fg='black')
-webui_path_entry.grid(row=2, column=1)
-ST_path_entry = tk.Entry(other_frame, textvariable=ST_path, width=25, bg=doki_white, fg='black')
-ST_path_entry.grid(row=2, column=1)
 
 load_from_json("GAME_PATH", game_path_entry)
-load_from_json("WEBUI_PATH", webui_path_entry)
-load_from_json("ST_PATH", ST_path_entry)
 
 tts_menu = tk.OptionMenu(other_frame, tts_model, "Your TTS", "XTTS", "Tortoise TTS")
 tts_menu.config(bg=doki_white, fg='black')
@@ -225,10 +146,7 @@ button.place(relx=0.5, rely=0.9, anchor=tk.CENTER)
 
 if not os.path.exists("config.json"):
     # Set default values
-    backend_choice.set("Text-gen-webui")
     launch_yourself.set(False)
-    launch_yourself_webui.set(False)
-    launch_yourself_ST.set(False)
     use_tts.set(False)
     use_actions.set(False)
     use_emotions.set(False) # Default for new option
@@ -240,14 +158,9 @@ else:
     with open("config.json", "r") as f:
         config = json.load(f)
     # Load existing settings
-    BACKEND_TYPE = config.get("BACKEND_TYPE", "Text-gen-webui")
     GAME_PATH = config.get("GAME_PATH", "")
-    WEBUI_PATH = config.get("WEBUI_PATH", "")
-    ST_PATH = config.get("ST_PATH", "")
     USE_TTS = config.get("USE_TTS", False)
     LAUNCH_YOURSELF = config.get("LAUNCH_YOURSELF", False)
-    LAUNCH_YOURSELF_WEBUI = config.get("LAUNCH_YOURSELF_WEBUI", False)
-    LAUNCH_YOURSELF_ST = config.get("LAUNCH_YOURSELF_ST", False)
     USE_ACTIONS = config.get("USE_ACTIONS", False)
     USE_EMOTIONS = config.get("USE_EMOTIONS", False) # Load new option
     TTS_MODEL = config.get("TTS_MODEL", "Your TTS")
@@ -255,10 +168,7 @@ else:
     VOICE_SAMPLE_COQUI = config.get("VOICE_SAMPLE_COQUI", "Choose a voice sample")
     VOICE_SAMPLE_TORTOISE = config.get("VOICE_SAMPLE_TORTOISE", "Choose a Tortoise voice sample")
     # Set saved values
-    backend_choice.set(BACKEND_TYPE)
     launch_yourself.set(LAUNCH_YOURSELF)
-    launch_yourself_webui.set(LAUNCH_YOURSELF_WEBUI)
-    launch_yourself_ST.set(LAUNCH_YOURSELF_ST)
     use_tts.set(USE_TTS)
     use_actions.set(USE_ACTIONS)
     use_emotions.set(USE_EMOTIONS) # Set GUI for new option
@@ -277,21 +187,14 @@ root.mainloop()
 # Convert string from radio buttons to boolean-like integers
 USE_TTS = int(eval(str(USE_TTS)))
 LAUNCH_YOURSELF = int(eval(str(LAUNCH_YOURSELF)))
-LAUNCH_YOURSELF_WEBUI = int(eval(str(LAUNCH_YOURSELF_WEBUI)))
-LAUNCH_YOURSELF_ST = int(eval(str(LAUNCH_YOURSELF_ST)))
 USE_ACTIONS = int(eval(str(USE_ACTIONS)))
 USE_EMOTIONS = int(eval(str(USE_EMOTIONS))) # Convert new option
 USE_SPEECH_RECOGNITION = int(eval(str(USE_SPEECH_RECOGNITION)))
 
 CONFIG = {
-    "BACKEND_TYPE": BACKEND_TYPE,
     "GAME_PATH": GAME_PATH,
-    "WEBUI_PATH": WEBUI_PATH,
-    "ST_PATH": ST_PATH,
     "USE_TTS": USE_TTS,
     "LAUNCH_YOURSELF": LAUNCH_YOURSELF,
-    "LAUNCH_YOURSELF_WEBUI": LAUNCH_YOURSELF_WEBUI,
-    "LAUNCH_YOURSELF_ST" : LAUNCH_YOURSELF_ST,
     "USE_ACTIONS": USE_ACTIONS,
     "USE_EMOTIONS": USE_EMOTIONS, # Add to config dict
     "TTS_MODEL": TTS_MODEL,

--- a/scripts/login_screen.py
+++ b/scripts/login_screen.py
@@ -32,13 +32,14 @@ def load_from_json(variable, entry):
         pass
 
 def get_input():
-    global GAME_PATH, USE_TTS, LAUNCH_YOURSELF
+    global GAME_PATH, USE_TTS, LAUNCH_YOURSELF, OLLAMA_MODEL
     global USE_ACTIONS, USE_EMOTIONS, TTS_MODEL, USE_SPEECH_RECOGNITION
     global VOICE_SAMPLE_TORTOISE, VOICE_SAMPLE_COQUI
     
     USE_TTS = use_tts.get()
     GAME_PATH = game_path.get()
     LAUNCH_YOURSELF = launch_yourself.get()
+    OLLAMA_MODEL = ollama_model.get()
     USE_ACTIONS = use_actions.get()
     USE_EMOTIONS = use_emotions.get() # Capture the new value
     TTS_MODEL = tts_model.get()
@@ -71,6 +72,7 @@ aspect_params = {
 use_tts = tk.StringVar()
 game_path = tk.StringVar()
 launch_yourself = tk.StringVar()
+ollama_model = tk.StringVar()
 use_actions = tk.StringVar()
 use_emotions = tk.StringVar() # Variable for the new option
 tts_model = tk.StringVar()
@@ -80,6 +82,7 @@ voice_sample_coqui = tk.StringVar()
 
 # General Settings Labels and Inputs
 tk.Label(other_frame, text="Game Path", bg=menu_background_pink, fg='white', font=bold_font).grid(row=1, column=0)
+tk.Label(other_frame, text="Ollama Model", bg=menu_background_pink, fg='white', font=bold_font).grid(row=2, column=0)
 tk.Label(other_frame, text="Launch Yourself", bg=menu_background_pink, fg='white', font=bold_font).grid(row=1, column=3)
 tk.Label(other_frame, text="Use Actions", bg=menu_background_pink, fg='white', font=bold_font).grid(row=3, column=0)
 tk.Label(other_frame, text="Use Emotions", bg=menu_background_pink, fg='white', font=bold_font).grid(row=4, column=0) # New Label
@@ -110,6 +113,11 @@ game_path_entry = tk.Entry(other_frame, textvariable=game_path, width=25, bg=dok
 game_path_entry.grid(row=1, column=1)
 
 load_from_json("GAME_PATH", game_path_entry)
+
+ollama_model_entry = tk.Entry(other_frame, textvariable=ollama_model, width=25, bg=doki_white, fg='black')
+ollama_model_entry.grid(row=2, column=1)
+
+load_from_json("OLLAMA_MODEL", ollama_model_entry)
 
 tts_menu = tk.OptionMenu(other_frame, tts_model, "Your TTS", "XTTS", "Tortoise TTS")
 tts_menu.config(bg=doki_white, fg='black')
@@ -159,6 +167,7 @@ else:
         config = json.load(f)
     # Load existing settings
     GAME_PATH = config.get("GAME_PATH", "")
+    OLLAMA_MODEL = config.get("OLLAMA_MODEL", "")
     USE_TTS = config.get("USE_TTS", False)
     LAUNCH_YOURSELF = config.get("LAUNCH_YOURSELF", False)
     USE_ACTIONS = config.get("USE_ACTIONS", False)
@@ -193,6 +202,7 @@ USE_SPEECH_RECOGNITION = int(eval(str(USE_SPEECH_RECOGNITION)))
 
 CONFIG = {
     "GAME_PATH": GAME_PATH,
+    "OLLAMA_MODEL": OLLAMA_MODEL,
     "USE_TTS": USE_TTS,
     "LAUNCH_YOURSELF": LAUNCH_YOURSELF,
     "USE_ACTIONS": USE_ACTIONS,


### PR DESCRIPTION
This pr is a proof of concept that replaces text-generation-ui, sillytavern and playwright components with an ollama backend.

This code is fully functional with the submod however it has the following limitations:

Hardcoded model chosen "llama3.2" due to it's small size.
Unable to unload model on exit.
Minor warnings about text context size that is not really an issue.

To test this code download and install Ollama here: https://github.com/ollama/ollama/releases/latest

To download llama 3.2, open a command prompt window and type: `ollama pull llama3.2`

Once it is downloaded just execute run.bat as normal. Ollama will load the model once you type your first message into MAS.

After exiting MAS, to unload the model, open a command prompt window and type: `ollama stop llama3.2`

We believe this will reduce the amount of overhead when running the submod.